### PR TITLE
Add react-jsx options to bsconfig

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -1,6 +1,9 @@
 {
   "name": "bs-date-fns",
   "bsc-flags": ["-bs-super-errors"],
+  "reason": {
+    "react-jsx": 3
+  },
   "refmt": 3,
   "sources": [
     {


### PR DESCRIPTION
This change fixes this issue with latest rescript compiler:
  Error: Unsupported jsx version 2